### PR TITLE
Add opened_only matcher for security groups

### DIFF
--- a/doc/resource_types.md
+++ b/doc/resource_types.md
@@ -1109,6 +1109,12 @@ end
 ```
 
 
+### be_inbound_opened_only
+
+### be_opened_only
+
+### be_outbound_opened_only
+
 ### its(:inbound), its(:outbound)
 
 ```ruby

--- a/lib/awspec/matcher.rb
+++ b/lib/awspec/matcher.rb
@@ -8,6 +8,7 @@ require 'awspec/matcher/belong_to_db_subnet_group'
 
 # SecurityGroup
 require 'awspec/matcher/be_opened'
+require 'awspec/matcher/be_opened_only'
 
 # Route53
 require 'awspec/matcher/have_record_set'

--- a/lib/awspec/matcher/be_opened_only.rb
+++ b/lib/awspec/matcher/be_opened_only.rb
@@ -1,0 +1,17 @@
+RSpec::Matchers.define :be_opened_only do |port|
+  match do |sg|
+    sg.opened_only?(port, @protocol, @cidr)
+  end
+
+  chain :protocol do |protocol|
+    @protocol = protocol
+  end
+
+  chain :for do |cidr|
+    @cidr = cidr
+  end
+
+  chain :target do |cidr|
+    @cidr = cidr
+  end
+end

--- a/lib/awspec/stub/security_group.rb
+++ b/lib/awspec/stub/security_group.rb
@@ -56,6 +56,17 @@ Aws.config[:ec2] = {
               user_id_group_pairs: []
             },
             {
+              from_port: 70_000,
+              to_port: 70_000,
+              ip_protocol: 'tcp',
+              ip_ranges: [
+                {
+                  cidr_ip: '101.456.789.012/32'
+                }
+              ],
+              user_id_group_pairs: []
+            },
+            {
               from_port: 50_000,
               to_port: 50_009,
               ip_protocol: 'tcp',

--- a/lib/awspec/stub/security_group.rb
+++ b/lib/awspec/stub/security_group.rb
@@ -34,6 +34,28 @@ Aws.config[:ec2] = {
               ]
             },
             {
+              from_port: 60_000,
+              to_port: 60_000,
+              ip_protocol: 'tcp',
+              ip_ranges: [
+                {
+                  cidr_ip: '100.456.789.012/32'
+                }
+              ],
+              user_id_group_pairs: []
+            },
+            {
+              from_port: 70_000,
+              to_port: 70_000,
+              ip_protocol: 'tcp',
+              ip_ranges: [
+                {
+                  cidr_ip: '100.456.789.012/32'
+                }
+              ],
+              user_id_group_pairs: []
+            },
+            {
               from_port: 50_000,
               to_port: 50_009,
               ip_protocol: 'tcp',
@@ -47,12 +69,12 @@ Aws.config[:ec2] = {
           ],
           ip_permissions_egress: [
             {
-              from_port: nil,
-              to_port: nil,
-              ip_protocol: '-1',
+              from_port: 50_000,
+              to_port: 50_000,
+              ip_protocol: 'tcp',
               ip_ranges: [
                 {
-                  cidr_ip: '0.0.0.0/0'
+                  cidr_ip: '100.456.789.012/32'
                 }
               ]
             }

--- a/lib/awspec/type/security_group.rb
+++ b/lib/awspec/type/security_group.rb
@@ -14,6 +14,11 @@ module Awspec::Type
       outbound_opened?(port, protocol, cidr)
     end
 
+    def opened_only?(port = nil, protocol = nil, cidr = nil)
+      return inbound_opened_only?(port, protocol, cidr) if @inbound
+      outbound_opened_only?(port, protocol, cidr)
+    end
+
     def inbound_opened?(port = nil, protocol = nil, cidr = nil)
       @resource_via_client[:ip_permissions].find do |permission|
         next true unless port
@@ -38,6 +43,18 @@ module Awspec::Type
       end
     end
 
+    def inbound_opened_only?(port = nil, protocol = nil, cidr = nil)
+      permissions = @resource_via_client[:ip_permissions].select do |permission|
+        port_between?(port, permission[:from_port], permission[:to_port])
+      end
+      permissions = permissions.select { |permission| permission[:ip_protocol] == protocol }
+      cidrs = []
+      permissions.each do |permission|
+        permission[:ip_ranges].select { |ip_range| cidrs.push(ip_range[:cidr_ip]) }
+      end
+      cidrs == [cidr]
+    end
+
     def outbound_opened?(port = nil, protocol = nil, cidr = nil)
       @resource_via_client[:ip_permissions_egress].find do |permission|
         next true unless port
@@ -60,6 +77,18 @@ module Awspec::Type
         end
         next true if ret.count > 0
       end
+    end
+
+    def outbound_opened_only?(port = nil, protocol = nil, cidr = nil)
+      permissions = @resource_via_client[:ip_permissions_egress].select do |permission|
+        port_between?(port, permission[:from_port], permission[:to_port])
+      end
+      permissions = permissions.select { |permission| permission[:ip_protocol] == protocol }
+      cidrs = []
+      permissions.each do |permission|
+        permission[:ip_ranges].select { |ip_range| cidrs.push(ip_range[:cidr_ip]) }
+      end
+      cidrs == [cidr]
     end
 
     def inbound

--- a/lib/awspec/type/security_group.rb
+++ b/lib/awspec/type/security_group.rb
@@ -52,7 +52,7 @@ module Awspec::Type
       permissions.each do |permission|
         permission[:ip_ranges].select { |ip_range| cidrs.push(ip_range[:cidr_ip]) }
       end
-      cidrs == [cidr]
+      cidrs == Array(cidr)
     end
 
     def outbound_opened?(port = nil, protocol = nil, cidr = nil)
@@ -88,7 +88,7 @@ module Awspec::Type
       permissions.each do |permission|
         permission[:ip_ranges].select { |ip_range| cidrs.push(ip_range[:cidr_ip]) }
       end
-      cidrs == [cidr]
+      cidrs == Array(cidr)
     end
 
     def inbound

--- a/spec/generator/spec/security_group_spec.rb
+++ b/spec/generator/spec/security_group_spec.rb
@@ -16,11 +16,12 @@ describe security_group('my-security-group-name') do
   its(:inbound) { should be_opened(22).protocol('tcp').for('group-name-sg') }
   its(:inbound) { should be_opened(60000).protocol('tcp').for('100.456.789.012/32') }
   its(:inbound) { should be_opened(70000).protocol('tcp').for('100.456.789.012/32') }
+  its(:inbound) { should be_opened(70000).protocol('tcp').for('101.456.789.012/32') }
   its(:inbound) { should be_opened('50000-50009').protocol('tcp').for('123.456.789.012/32') }
   its(:outbound) { should be_opened(50000).protocol('tcp').for('100.456.789.012/32') }
-  its(:inbound_rule_count) { should eq 6 }
+  its(:inbound_rule_count) { should eq 7 }
   its(:outbound_rule_count) { should eq 1 }
-  its(:inbound_permissions_count) { should eq 5 }
+  its(:inbound_permissions_count) { should eq 6 }
   its(:outbound_permissions_count) { should eq 1 }
   it { should belong_to_vpc('my-vpc') }
 end

--- a/spec/generator/spec/security_group_spec.rb
+++ b/spec/generator/spec/security_group_spec.rb
@@ -14,11 +14,13 @@ describe security_group('my-security-group-name') do
   its(:inbound) { should be_opened(80).protocol('tcp').for('123.456.789.012/32') }
   its(:inbound) { should be_opened(80).protocol('tcp').for('456.789.123.456/32') }
   its(:inbound) { should be_opened(22).protocol('tcp').for('group-name-sg') }
+  its(:inbound) { should be_opened(60000).protocol('tcp').for('100.456.789.012/32') }
+  its(:inbound) { should be_opened(70000).protocol('tcp').for('100.456.789.012/32') }
   its(:inbound) { should be_opened('50000-50009').protocol('tcp').for('123.456.789.012/32') }
-  its(:outbound) { should be_opened }
-  its(:inbound_rule_count) { should eq 4 }
+  its(:outbound) { should be_opened(50000).protocol('tcp').for('100.456.789.012/32') }
+  its(:inbound_rule_count) { should eq 6 }
   its(:outbound_rule_count) { should eq 1 }
-  its(:inbound_permissions_count) { should eq 3 }
+  its(:inbound_permissions_count) { should eq 5 }
   its(:outbound_permissions_count) { should eq 1 }
   it { should belong_to_vpc('my-vpc') }
 end

--- a/spec/type/security_group_spec.rb
+++ b/spec/type/security_group_spec.rb
@@ -10,12 +10,15 @@ describe security_group('sg-1a2b3cd4') do
   its(:inbound) { should be_opened(22).protocol('tcp').for('sg-5a6b7cd8') }
   its(:inbound) { should be_opened('50000-50009').protocol('tcp').for('123.456.789.012/32') }
   its(:inbound) { should_not be_opened('50010-50019').protocol('tcp').for('123.456.789.012/32') }
-  its(:outbound) { should be_opened }
-  its(:inbound_permissions_count) { should eq 3 }
-  its(:ip_permissions_count) { should eq 3 }
+  its(:outbound) { should be_opened(50_000) }
+  its(:inbound) { should be_opened_only(60_000).protocol('tcp').for('100.456.789.012/32') }
+  its(:inbound) { should be_opened_only(70_000).protocol('tcp').for('100.456.789.012/32') }
+  its(:outbound) { should be_opened_only(50_000).protocol('tcp').for('100.456.789.012/32') }
+  its(:inbound_permissions_count) { should eq 5 }
+  its(:ip_permissions_count) { should eq 5 }
   its(:outbound_permissions_count) { should eq 1 }
   its(:ip_permissions_egress_count) { should eq 1 }
-  its(:inbound_rule_count) { should eq 4 }
+  its(:inbound_rule_count) { should eq 6 }
   its(:outbound_rule_count) { should eq 1 }
   # its(:inbound) { should be_opened(22).protocol('tcp').for('group-name-sg') }
   # its(:inbound) { should be_opened(22).protocol('tcp').for('my-db-sg') }
@@ -29,13 +32,13 @@ end
 
 describe security_group('my-security-group-name') do
   it { should exist }
-  its(:outbound) { should be_opened }
+  its(:outbound) { should be_opened(50_000) }
   its(:inbound) { should be_opened(80) }
   it { should belong_to_vpc('my-vpc') }
 end
 
 describe security_group('my-security-tag-name') do
-  its(:outbound) { should be_opened }
+  its(:outbound) { should be_opened(50_000) }
   its(:inbound) { should be_opened(80) }
   it { should belong_to_vpc('my-vpc') }
 end

--- a/spec/type/security_group_spec.rb
+++ b/spec/type/security_group_spec.rb
@@ -12,13 +12,13 @@ describe security_group('sg-1a2b3cd4') do
   its(:inbound) { should_not be_opened('50010-50019').protocol('tcp').for('123.456.789.012/32') }
   its(:outbound) { should be_opened(50_000) }
   its(:inbound) { should be_opened_only(60_000).protocol('tcp').for('100.456.789.012/32') }
-  its(:inbound) { should be_opened_only(70_000).protocol('tcp').for('100.456.789.012/32') }
+  its(:inbound) { should be_opened_only(70_000).protocol('tcp').for(['100.456.789.012/32', '101.456.789.012/32']) }
   its(:outbound) { should be_opened_only(50_000).protocol('tcp').for('100.456.789.012/32') }
-  its(:inbound_permissions_count) { should eq 5 }
-  its(:ip_permissions_count) { should eq 5 }
+  its(:inbound_permissions_count) { should eq 6 }
+  its(:ip_permissions_count) { should eq 6 }
   its(:outbound_permissions_count) { should eq 1 }
   its(:ip_permissions_egress_count) { should eq 1 }
-  its(:inbound_rule_count) { should eq 6 }
+  its(:inbound_rule_count) { should eq 7 }
   its(:outbound_rule_count) { should eq 1 }
   # its(:inbound) { should be_opened(22).protocol('tcp').for('group-name-sg') }
   # its(:inbound) { should be_opened(22).protocol('tcp').for('my-db-sg') }


### PR DESCRIPTION
Not sure how well this fits in with the overall development plan. My company needs this for our use of awspec, and it seems silly not to contribute back to core. I'd be happy to make any changes y'all see fit, or move it into a plugin-type infrastructure if you have that. Please let me know!

This matcher allows the user to make exclusivity statements about certain rules.
Prior, a user could only make statements about the existence of opened rules for
security groups, now they can state that not only is there an opened rule but that
that is the _only_ open rule for a given port, protocol.

The specs and stubs were reworked only to ensure testability of this new matcher without creating any new stubs. Again, happy to go in a different direction if you're up for larger scale changes to the organization of the specs/stubs.
